### PR TITLE
chore: support multiple btc node

### DIFF
--- a/config.mainnet/config.yaml
+++ b/config.mainnet/config.yaml
@@ -20,9 +20,6 @@ sync:
   rgbppBtcCodeHash: "0xbc6c568a1a0d0a09f6844dc9d74ddb4343c32143ff25f727c59edf4fb72d6936"
   rgbppBtcHashType: "type"
 
-  rgbppBtcTimelockCodeHash: ""
-  rgbppBtcTimelockHashType: "type"
-
   udtTypes:
     # sUDT
     - codeHash: "0x5e7a36a77e68eecc013dfa2fe6a23f3b6c344b04005808694ae6dd45eea4cfd5"
@@ -30,11 +27,25 @@ sync:
     # xUDT
     - codeHash: "0x50bd8d6680b8b9cf98b73f3c08faf8b2a21914311954118ad6609be6e78a1b95"
       hashType: "data1"
+    # xUDT Compatible 1
+    - codeHash: "0x092c2c4a26ea475a8e860c29cf00502103add677705e2ccd8d6fe5af3caa5ae3"
+      hashType: "type"
+    # xUDT Compatible 2
+    - codeHash: "0x26a33e0815888a4a0614a0b7d09fa951e0993ff21e55905510104a0b1312032b"
+      hashType: "type"
+    # xUDT Compatible 3
+    - codeHash: "0x42a0b2aacc836c0fc2bbd421a9020de42b8411584190f30be547fdf54214acc3"
+      hashType: "type"
+    # xUDT Compatible 4
+    - codeHash: "0xbfa35a9c38a676682b65ade8f02be164d48632281477e36f8dc2f41f79e56bfc"
+      hashType: "type"
 
   isMainnet: true
   maxConcurrent: 1024
   ckbRpcTimeout: 60000
   ckbRpcUri: wss://mainnet.ckb.dev/ws
-  btcRpcUri: https://rpc.ankr.com/btc
   decoderServerUri: http://decoder:8090
   ssriServerUri: http://ssri:9090
+
+  btcRpcUris: 
+    - https://rpc.ankr.com/btc

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -20,16 +20,25 @@ sync:
   rgbppBtcCodeHash: "0xd07598deec7ce7b5665310386b4abd06a6d48843e953c5cc2112ad0d5a220364"
   rgbppBtcHashType: "type"
 
-  rgbppBtcTimelockCodeHash: ""
-  rgbppBtcTimelockHashType: "type"
-
   udtTypes:
     # sUDT
     - codeHash: "0x48dbf59b4c7ee1547238021b4869bceedf4eea6b43772e5d66ef8865b6ae7212"
       hashType: "data"
+    # sUDT
+    - codeHash: "0xc5e5dcf215925f7ef4dfaf5f4b4f105bc321c02776d6e7d52a1db3fcd9d011a4"
+      hashType: "type"
     # xUDT
     - codeHash: "0x50bd8d6680b8b9cf98b73f3c08faf8b2a21914311954118ad6609be6e78a1b95"
       hashType: "data1"
+    # xUDT Compatible 1
+    - codeHash: "0x98701eaf939113606a8a70013fd2e8f27b8f1e234acdc329f3d71f9e9d3d3233"
+      hashType: "type"
+    # xUDT Compatible 2
+    - codeHash: "0x1142755a044bf2ee358cba9f2da187ce928c91cd4dc8692ded0337efa677d21a"
+      hashType: "type"
+    # xUDT Compatible 3
+    - codeHash: "0xcc9dc33ef234e14bc788c43a4848556a5fb16401a04662fc55db9bb201987037"
+      hashType: "type"
     # xUDT(final_rls)
     - codeHash: "0x25c29dc317811a6f6f3985a7a9ebc4838bd388d19d0feeecf0bcd60f6c0975bb"
       hashType: "type"
@@ -38,6 +47,8 @@ sync:
   maxConcurrent: 1024
   ckbRpcTimeout: 60000
   ckbRpcUri: wss://testnet.ckb.dev/ws
-  btcRpcUri: https://rpc.ankr.com/btc_signet
   decoderServerUri: http://decoder:8090
   ssriServerUri: http://ssri:9090
+
+  btcRpcUris:
+    - https://rpc.ankr.com/btc_signet

--- a/libs/asset/src/asset.service.ts
+++ b/libs/asset/src/asset.service.ts
@@ -21,7 +21,7 @@ export class AssetService {
     codeHash: ccc.HexLike;
     hashType: ccc.HashTypeLike;
   }[];
-  private readonly btcRequester: AxiosInstance;
+  private readonly btcRequesters: AxiosInstance[];
 
   constructor(
     private readonly configService: ConfigService,
@@ -42,10 +42,8 @@ export class AssetService {
       assertConfig(configService, "sync.rgbppBtcHashType"),
     );
 
-    const btcRpcUri = assertConfig<string>(configService, "sync.btcRpcUri");
-    this.btcRequester = axios.create({
-      baseURL: btcRpcUri,
-    });
+    const btcRpcUris = assertConfig<string[]>(configService, "sync.btcRpcUris");
+    this.btcRequesters = btcRpcUris.map((baseURL) => axios.create({ baseURL }));
 
     const udtTypes =
       configService.get<
@@ -76,7 +74,7 @@ export class AssetService {
       return parseBtcAddress({
         client: this.client,
         rgbppScript: scriptLike,
-        requester: this.btcRequester,
+        requesters: this.btcRequesters,
       });
     }
     const script = ccc.Script.from(scriptLike);

--- a/libs/spore/src/spore.service.ts
+++ b/libs/spore/src/spore.service.ts
@@ -12,7 +12,7 @@ export class SporeService {
   private readonly client: ccc.Client;
   private readonly rgbppBtcCodeHash: ccc.Hex;
   private readonly rgbppBtcHashType: ccc.HashType;
-  private readonly btcRequester: AxiosInstance;
+  private readonly btcRequesters: AxiosInstance[];
 
   constructor(
     private readonly configService: ConfigService,
@@ -32,10 +32,8 @@ export class SporeService {
       assertConfig(configService, "sync.rgbppBtcHashType"),
     );
 
-    const btcRpcUri = assertConfig<string>(configService, "sync.btcRpcUri");
-    this.btcRequester = axios.create({
-      baseURL: btcRpcUri,
-    });
+    const btcRpcUris = assertConfig<string[]>(configService, "sync.btcRpcUris");
+    this.btcRequesters = btcRpcUris.map((baseURL) => axios.create({ baseURL }));
   }
 
   async scriptToAddress(scriptLike: ccc.ScriptLike): Promise<string> {
@@ -46,7 +44,7 @@ export class SporeService {
       return parseBtcAddress({
         client: this.client,
         rgbppScript: scriptLike,
-        requester: this.btcRequester,
+        requesters: this.btcRequesters,
       });
     }
     const script = ccc.Script.from(scriptLike);

--- a/libs/sync/src/sporeParser.ts
+++ b/libs/sync/src/sporeParser.ts
@@ -22,7 +22,7 @@ export class SporeParserBuilder {
   public readonly client: ccc.Client;
   public readonly decoderUri: string;
 
-  public readonly btcRequester: AxiosInstance;
+  public readonly btcRequesters: AxiosInstance[];
   public readonly rgbppBtcCodeHash: ccc.Hex;
   public readonly rgbppBtcHashType: ccc.HashType;
 
@@ -38,15 +38,15 @@ export class SporeParserBuilder {
       : new ccc.ClientPublicTestnet({ url: ckbRpcUri });
 
     this.decoderUri = assertConfig(configService, "sync.decoderServerUri");
-    this.btcRequester = axios.create({
-      baseURL: assertConfig(configService, "sync.btcRpcUri"),
-    });
     this.rgbppBtcCodeHash = ccc.hexFrom(
       assertConfig(configService, "sync.rgbppBtcCodeHash"),
     );
     this.rgbppBtcHashType = ccc.hashTypeFrom(
       assertConfig(configService, "sync.rgbppBtcHashType"),
     );
+
+    const btcRpcUris = assertConfig<string[]>(configService, "sync.btcRpcUris");
+    this.btcRequesters = btcRpcUris.map((baseURL) => axios.create({ baseURL }));
   }
 
   build(blockHeight: ccc.NumLike): SporeParser {
@@ -61,7 +61,7 @@ export class SporeParserBuilder {
       return parseBtcAddress({
         client: this.client,
         rgbppScript: scriptLike,
-        requester: this.btcRequester,
+        requesters: this.btcRequesters,
       });
     }
     const script = ccc.Script.from(scriptLike);


### PR DESCRIPTION
# Description

1. support parsing btc address from multiple btc node rpcs
2. expand udt-like type script information on testnet and mainnet configs 