### PR TITLE
feat: get balances from batch addresses

### DIFF
--- a/config.mainnet/config.yaml
+++ b/config.mainnet/config.yaml
@@ -20,6 +20,9 @@ sync:
   rgbppBtcCodeHash: "0xbc6c568a1a0d0a09f6844dc9d74ddb4343c32143ff25f727c59edf4fb72d6936"
   rgbppBtcHashType: "type"
 
+  rgbppBtcTimelockCodeHash: "0x70d64497a075bd651e98ac030455ea200637ee325a12ad08aff03f1a117e5a62"
+  rgbppBtcTimelockHashType: "type"
+
   udtTypes:
     # sUDT
     - codeHash: "0x5e7a36a77e68eecc013dfa2fe6a23f3b6c344b04005808694ae6dd45eea4cfd5"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -20,6 +20,9 @@ sync:
   rgbppBtcCodeHash: "0xd07598deec7ce7b5665310386b4abd06a6d48843e953c5cc2112ad0d5a220364"
   rgbppBtcHashType: "type"
 
+  rgbppBtcTimelockCodeHash: "0x80a09eca26d77cea1f5a69471c59481be7404febf40ee90f886c36a948385b55"
+  rgbppBtcTimelockHashType: "type"
+
   udtTypes:
     # sUDT
     - codeHash: "0x48dbf59b4c7ee1547238021b4869bceedf4eea6b43772e5d66ef8865b6ae7212"

--- a/libs/asset/src/asset.controller.ts
+++ b/libs/asset/src/asset.controller.ts
@@ -373,7 +373,7 @@ export class AssetController {
           block.header.number,
         );
         if (
-          txAssetCellData.inputs.length > 0 &&
+          txAssetCellData.inputs.length > 0 ||
           txAssetCellData.outputs.length > 0
         ) {
           txAssetCellDataList.push(txAssetCellData);

--- a/libs/asset/src/asset.service.ts
+++ b/libs/asset/src/asset.service.ts
@@ -10,7 +10,7 @@ import { ccc } from "@ckb-ccc/shell";
 import { cccA } from "@ckb-ccc/shell/advanced";
 import { Inject, Injectable } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
-import axios, { AxiosInstance } from "axios";
+import { AxiosInstance } from "axios";
 import { ClusterRepo, SporeRepo, UdtInfoRepo } from "./repos";
 
 @Injectable()

--- a/libs/block/src/block.controller.ts
+++ b/libs/block/src/block.controller.ts
@@ -7,8 +7,8 @@ import {
   RpcError,
 } from "@app/commons";
 import { ccc } from "@ckb-ccc/shell";
-import { Controller, Get, Param } from "@nestjs/common";
-import { ApiOkResponse } from "@nestjs/swagger";
+import { Controller, Get, Param, Query } from "@nestjs/common";
+import { ApiOkResponse, ApiQuery } from "@nestjs/swagger";
 import { BlockService } from "./block.service";
 
 (BigInt.prototype as unknown as { toJSON: () => string }).toJSON = function () {
@@ -23,12 +23,21 @@ export class BlockController {
     type: BlockHeader,
     description: "Get tip block",
   })
+  @ApiQuery({
+    name: "fromDb",
+    required: false,
+    default: true,
+    description:
+      "Determine whether to get the block from the database or from the CKB node",
+  })
   @Get("/blocks/latest")
-  async getLatestBlock(): Promise<NormalizedReturn<BlockHeader>> {
+  async getLatestBlock(
+    @Query("fromDb") fromDb: boolean = true,
+  ): Promise<NormalizedReturn<BlockHeader>> {
     try {
       const tipHeader = assert(
         await this.service.getBlockHeader({
-          fromDb: false,
+          fromDb,
         }),
         RpcError.BlockNotFound,
       );
@@ -57,15 +66,23 @@ export class BlockController {
     type: BlockHeader,
     description: "Get block by block number",
   })
+  @ApiQuery({
+    name: "fromDb",
+    required: false,
+    default: true,
+    description:
+      "Determine whether to get the block from the database or from the CKB node",
+  })
   @Get("/blocks/by-number/:blockNumber")
   async getBlockHeaderByNumber(
     @Param("blockNumber") blockNumber: number,
+    @Query("fromDb") fromDb: boolean = true,
   ): Promise<NormalizedReturn<BlockHeader>> {
     try {
       const blockHeader = assert(
         await this.service.getBlockHeader({
           blockNumber,
-          fromDb: false,
+          fromDb,
         }),
         RpcError.BlockNotFound,
       );

--- a/libs/cell/src/cell.controller.ts
+++ b/libs/cell/src/cell.controller.ts
@@ -129,15 +129,25 @@ export class CellController {
     type: TokenCell,
     description: "Get an on-chain cell by CKB OutPoint",
   })
+  @ApiQuery({
+    name: "containSpender",
+    required: false,
+    description:
+      "Whether to include the spender information of the cell, default is false (optional)",
+  })
   @Get("/cells/by-outpoint/:txHash/:index")
   async getCellByOutpoint(
     @Param("txHash") txHash: string,
     @Param("index") index: number,
-    @Query("containSpender") containSpender: boolean,
+    @Query("containSpender") containSpender?: boolean,
   ): Promise<NormalizedReturn<TokenCell>> {
     try {
       const { cell, spender } = assert(
-        await this.service.getCellByOutpoint(txHash, index, containSpender),
+        await this.service.getCellByOutpoint(
+          txHash,
+          index,
+          containSpender ?? false,
+        ),
         RpcError.CkbCellNotFound,
       );
       assert(cell.cellOutput.type, RpcError.CellNotAsset);

--- a/libs/cell/src/cell.controller.ts
+++ b/libs/cell/src/cell.controller.ts
@@ -58,13 +58,22 @@ export class CellController {
       }
     }
     // rgbpp timelock related modes
-    for (const { mode, chain } of [
-      { mode: ScriptMode.RgbppBtcTimelock, chain: Chain.Btc },
-      { mode: ScriptMode.RgbppDogeTimelock, chain: Chain.Doge },
+    for (const { mode, premode, chain } of [
+      {
+        mode: ScriptMode.RgbppBtcTimelock,
+        premode: ScriptMode.RgbppBtc,
+        chain: Chain.Btc,
+      },
+      {
+        mode: ScriptMode.RgbppDogeTimelock,
+        premode: ScriptMode.RgbppDoge,
+        chain: Chain.Doge,
+      },
     ]) {
       if (lockScriptMode === mode) {
+        console.log("premode = ", premode);
         const rgbppScript = assert(
-          await this.service.getScriptByModeFromTxInputs(tx, mode),
+          await this.service.getScriptByModeFromTxInputs(tx, premode),
           RpcError.RgbppCellNotFound,
         );
         const isomorphicInfo = assert(

--- a/libs/cell/src/cell.controller.ts
+++ b/libs/cell/src/cell.controller.ts
@@ -71,7 +71,6 @@ export class CellController {
       },
     ]) {
       if (lockScriptMode === mode) {
-        console.log("premode = ", premode);
         const rgbppScript = assert(
           await this.service.getScriptByModeFromTxInputs(tx, premode),
           RpcError.RgbppCellNotFound,

--- a/libs/cell/src/cell.service.ts
+++ b/libs/cell/src/cell.service.ts
@@ -106,11 +106,11 @@ export class CellService {
     scriptMode: ScriptMode,
   ): Promise<ccc.Script | undefined> {
     for (const input of tx.inputs) {
-      const script = await this.client
-        .getCellLive(input.previousOutput)
-        .then((cell) => cell?.cellOutput.lock);
+      await input.completeExtraInfos(this.client);
+      const script = input.cellOutput?.lock;
       if (script) {
         const lockScriptMode = await this.scriptMode(script);
+        console.log("lockScriptMode = ", lockScriptMode);
         if (scriptMode === lockScriptMode) {
           return script;
         }

--- a/libs/cell/src/cell.service.ts
+++ b/libs/cell/src/cell.service.ts
@@ -18,6 +18,9 @@ export class CellService {
   private readonly client: ccc.Client;
   private readonly rgbppBtcCodeHash: ccc.Hex;
   private readonly rgbppBtcHashType: ccc.HashType;
+  private readonly rgbppBtcTimelockCodeHash: ccc.Hex;
+  private readonly rgbppBtcTimelockHashType: ccc.HashType;
+  private readonly btcRequesters: AxiosInstance[];
   private readonly udtTypes: {
     codeHash: ccc.HexLike;
     hashType: ccc.HashTypeLike;
@@ -41,6 +44,16 @@ export class CellService {
       assertConfig(configService, "sync.rgbppBtcHashType"),
     );
 
+    this.rgbppBtcTimelockCodeHash = ccc.hexFrom(
+      assertConfig(configService, "sync.rgbppBtcTimelockCodeHash"),
+    );
+    this.rgbppBtcTimelockHashType = ccc.hashTypeFrom(
+      assertConfig(configService, "sync.rgbppBtcTimelockHashType"),
+    );
+
+    const btcRpcUris = assertConfig<string[]>(configService, "sync.btcRpcUris");
+    this.btcRequesters = btcRpcUris.map((baseURL) => axios.create({ baseURL }));
+
     const udtTypes =
       configService.get<
         { codeHash: ccc.HexLike; hashType: ccc.HashTypeLike }[]
@@ -58,6 +71,11 @@ export class CellService {
       codeHash: this.rgbppBtcCodeHash,
       hashType: this.rgbppBtcHashType,
       mode: ScriptMode.RgbppBtc,
+    });
+    extension.push({
+      codeHash: this.rgbppBtcTimelockCodeHash,
+      hashType: this.rgbppBtcTimelockHashType,
+      mode: ScriptMode.RgbppBtcTimelock,
     });
     return await parseScriptMode(script, this.client, extension);
   }
@@ -77,9 +95,33 @@ export class CellService {
     return ccc.Address.fromScript(script, this.client).toString();
   }
 
+  async getTxByCell(cell: ccc.Cell): Promise<ccc.Transaction | undefined> {
+    return await this.client
+      .getTransaction(cell.outPoint.txHash)
+      .then((tx) => tx?.transaction);
+  }
+
+  async getScriptByModeFromTxInputs(
+    tx: ccc.Transaction,
+    scriptMode: ScriptMode,
+  ): Promise<ccc.Script | undefined> {
+    for (const input of tx.inputs) {
+      const script = await this.client
+        .getCellLive(input.previousOutput)
+        .then((cell) => cell?.cellOutput.lock);
+      if (script) {
+        const lockScriptMode = await this.scriptMode(script);
+        if (scriptMode === lockScriptMode) {
+          return script;
+        }
+      }
+    }
+  }
+
   async getCellByOutpoint(
     txHash: ccc.HexLike,
     index: number,
+    containSpender: boolean,
   ): Promise<
     | {
         cell: ccc.Cell;
@@ -90,7 +132,7 @@ export class CellService {
     const cell = await this.client.getCell({ txHash, index });
     if (cell) {
       // If the cell is not an asset, skip finding the spender
-      if (cell.cellOutput.type === undefined) {
+      if (cell.cellOutput.type === undefined || !containSpender) {
         return {
           cell,
         };
@@ -137,7 +179,6 @@ export class CellService {
           };
         }
       }
-      console.log("no spender found");
       return {
         cell,
       };

--- a/libs/cell/src/cell.service.ts
+++ b/libs/cell/src/cell.service.ts
@@ -10,7 +10,7 @@ import {
 import { ccc } from "@ckb-ccc/shell";
 import { Inject, Injectable } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
-import axios, { AxiosInstance } from "axios";
+import { AxiosInstance } from "axios";
 import { UdtInfoRepo } from "./repos";
 
 @Injectable()
@@ -20,7 +20,6 @@ export class CellService {
   private readonly rgbppBtcHashType: ccc.HashType;
   private readonly rgbppBtcTimelockCodeHash: ccc.Hex;
   private readonly rgbppBtcTimelockHashType: ccc.HashType;
-  private readonly btcRequesters: AxiosInstance[];
   private readonly udtTypes: {
     codeHash: ccc.HexLike;
     hashType: ccc.HashTypeLike;
@@ -50,9 +49,6 @@ export class CellService {
     this.rgbppBtcTimelockHashType = ccc.hashTypeFrom(
       assertConfig(configService, "sync.rgbppBtcTimelockHashType"),
     );
-
-    const btcRpcUris = assertConfig<string[]>(configService, "sync.btcRpcUris");
-    this.btcRequesters = btcRpcUris.map((baseURL) => axios.create({ baseURL }));
 
     const udtTypes =
       configService.get<

--- a/libs/cell/src/cell.service.ts
+++ b/libs/cell/src/cell.service.ts
@@ -106,7 +106,6 @@ export class CellService {
       const script = input.cellOutput?.lock;
       if (script) {
         const lockScriptMode = await this.scriptMode(script);
-        console.log("lockScriptMode = ", lockScriptMode);
         if (scriptMode === lockScriptMode) {
           return script;
         }

--- a/libs/commons/src/ormUtils/index.ts
+++ b/libs/commons/src/ormUtils/index.ts
@@ -30,7 +30,8 @@ export async function foreachInRepo<T>({
   while (true) {
     const entities = await repo.find({
       where: lastId
-        ? ({ ...(criteria ?? {}), id: MoreThan(lastId) } as any)
+        ? /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+          ({ ...(criteria ?? {}), id: MoreThan(lastId) } as any)
         : criteria,
       order,
       take: chunkSize ?? 100,

--- a/libs/commons/src/rest/index.ts
+++ b/libs/commons/src/rest/index.ts
@@ -10,6 +10,8 @@ export enum Chain {
 export enum ScriptMode {
   RgbppBtc = "rgbppBtc",
   RgbppDoge = "rgbppDoge",
+  RgbppBtcTimelock = "rgbppBtcTimelock",
+  RgbppDogeTimelock = "rgbppDogeTimelock",
   SingleUseLock = "singleUseLock",
   OmniLock = "omniLock",
   Udt = "udt",
@@ -27,6 +29,12 @@ enum ApiHashType {
   Type = "type",
   Data1 = "data1",
   Data2 = "data2",
+}
+
+export enum LeapType {
+  None = 0,
+  FromUtxo = 1,
+  ToUtxo = 2,
 }
 
 export class NormalizedReturn<T> {
@@ -86,6 +94,8 @@ export class TokenBalance {
   address: string;
   @ApiProperty({ type: Number })
   balance: ccc.Num;
+  @ApiProperty({ type: Number })
+  height: ccc.Num;
 }
 
 export class BlockHeader {
@@ -211,6 +221,8 @@ export class TokenData {
   tokenId: ccc.Hex;
   @ApiProperty({ type: Number })
   amount: ccc.Num;
+  @ApiProperty()
+  mintable: boolean;
   @ApiPropertyOptional()
   name?: string;
   @ApiPropertyOptional()
@@ -226,6 +238,8 @@ export class IsomorphicBinding {
   txHash: ccc.Hex;
   @ApiProperty({ type: Number })
   vout: number;
+  @ApiProperty({ enum: LeapType })
+  leapType: LeapType;
 }
 
 export class TxAssetCellDetail {

--- a/libs/commons/src/utils/index.ts
+++ b/libs/commons/src/utils/index.ts
@@ -67,6 +67,7 @@ export enum RpcError {
   CellNotAsset,
   ClusterNotFound,
   SporeNotFound,
+  IsomorphicBindingNotFound,
 }
 
 export const RpcErrorMessage: Record<RpcError, string> = {
@@ -78,6 +79,7 @@ export const RpcErrorMessage: Record<RpcError, string> = {
   [RpcError.CellNotAsset]: "Cell is not an asset",
   [RpcError.ClusterNotFound]: "Cluster not found",
   [RpcError.SporeNotFound]: "Spore not found",
+  [RpcError.IsomorphicBindingNotFound]: "Isomorphic binding not found",
 };
 
 export class ApiError {
@@ -279,4 +281,15 @@ export function extractIsomorphicInfo(
 
   const { outIndex, txId } = decoded;
   return { txHash: txId, index: outIndex };
+}
+
+export function mintableScriptMode(scriptMode: ScriptMode): boolean {
+  const unmintable = [
+    ScriptMode.SingleUseLock,
+    ScriptMode.RgbppBtc,
+    ScriptMode.RgbppDoge,
+    ScriptMode.RgbppBtcTimelock,
+    ScriptMode.RgbppDogeTimelock,
+  ].includes(scriptMode);
+  return !unmintable;
 }

--- a/libs/spore/src/spore.service.ts
+++ b/libs/spore/src/spore.service.ts
@@ -3,7 +3,7 @@ import { Cluster, Spore } from "@app/schemas";
 import { ccc } from "@ckb-ccc/shell";
 import { Inject, Injectable, Logger } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
-import axios, { AxiosInstance } from "axios";
+import { AxiosInstance } from "axios";
 import { ClusterRepo, SporeRepo } from "./repos";
 
 @Injectable()

--- a/libs/sync/src/sporeParser.ts
+++ b/libs/sync/src/sporeParser.ts
@@ -11,7 +11,7 @@ import { cccA } from "@ckb-ccc/shell/advanced";
 import { spore } from "@ckb-ccc/spore";
 import { Inject, Injectable, Logger } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
-import axios, { AxiosInstance } from "axios";
+import { AxiosInstance } from "axios";
 import { EntityManager } from "typeorm";
 import { ClusterRepo } from "./repos/cluster.repo";
 import { SporeRepo } from "./repos/spore.repo";

--- a/libs/udt/src/udt.controller.ts
+++ b/libs/udt/src/udt.controller.ts
@@ -136,6 +136,12 @@ export class UdtController {
       tokenId,
       height ? ccc.numFrom(height) : undefined,
     );
+    if (udtBalances.length === 0) {
+      return {
+        code: -1,
+        msg: "No token balances found",
+      };
+    }
     return {
       code: 0,
       data: await asyncMap(
@@ -166,6 +172,12 @@ export class UdtController {
       addresses.split(","),
       height ? ccc.numFrom(height) : undefined,
     );
+    if (udtBalances.length === 0) {
+      return {
+        code: -1,
+        msg: "No token balances found",
+      };
+    }
     return {
       code: 0,
       data: await asyncMap(
@@ -201,6 +213,12 @@ export class UdtController {
       isNaN(offset) ? 0 : offset,
       isNaN(limit) ? 10 : limit,
     );
+    if (udtBalances.length === 0) {
+      return {
+        code: -1,
+        msg: "No token balances found",
+      };
+    }
     const udtBalanceTotal = await this.service.getTokenHoldersCount(tokenId);
     return {
       code: 0,

--- a/libs/udt/src/udt.service.ts
+++ b/libs/udt/src/udt.service.ts
@@ -97,11 +97,28 @@ export class UdtService {
     return this.udtBalanceRepo.getItemCountByTokenHash(tokenId);
   }
 
-  async getTokenBalance(
+  async getTokenBalanceByAddress(
     address: string,
     tokenId?: ccc.HexLike,
+    height?: ccc.Num,
   ): Promise<UdtBalance[]> {
-    return await this.udtBalanceRepo.getTokenItemsByAddress(address, tokenId);
+    return await this.udtBalanceRepo.getTokenItemsByAddress(
+      [address],
+      tokenId,
+      height,
+    );
+  }
+
+  async getTokenBalanceByTokenId(
+    tokenId: ccc.HexLike,
+    addresses: string[],
+    height?: ccc.Num,
+  ): Promise<UdtBalance[]> {
+    return await this.udtBalanceRepo.getTokenItemsByAddress(
+      addresses,
+      tokenId,
+      height,
+    );
   }
 
   async getTokenAllBalances(


### PR DESCRIPTION
# Description

1. `getCellByOutpoint` should contain `containSpender` parameter to scanning the cell spender for true or not for false
2. add new method `batchGetUserTokenHolders`, which query multiple addresses under a token id from db
3. optimize pure sql queries by DeepSeek-v3, for example, reduce the table scanning from twice to once
4. add back `mintable` and rgbpp binding `leapType` flags, the first is to show a udt token is mintable, the second is to show a rgbpp movement direction, which containing `None, FromUtxoChain and ToUtxoChain`, in this case, the btc timelock script information should be taken advantage for the direction analysis
5. transparent `fromDb` option for block APIs