### PR TITLE
feat: save transactions and parse udt owner in sync module

### DIFF
--- a/config.mainnet/config.yaml
+++ b/config.mainnet/config.yaml
@@ -25,6 +25,7 @@ sync:
   clearInterval: 1800000
   confirmations: 100
   txCacheComfirmations: 1000000
+  txBatchMaxSize: 1048576 # 1MB
 
   rgbppBtcCodeHash: "0xbc6c568a1a0d0a09f6844dc9d74ddb4343c32143ff25f727c59edf4fb72d6936"
   rgbppBtcHashType: "type"

--- a/config.mainnet/config.yaml
+++ b/config.mainnet/config.yaml
@@ -18,10 +18,13 @@ sync:
   threads: 8
   blockChunk: 100
   blockLimitPerInterval: 50000
-  blockSyncStart: 11922670
+  blockSyncStart: 2624950 # sUDT starts from here
 
+  # once `clearInterval` and `confirmations` set, enable automatic CLEAR process,
+  # while clearing from db, cached txs will be removed once the `txCacheConfirmations` is set
   clearInterval: 1800000
   confirmations: 100
+  txCacheComfirmations: 100000
 
   rgbppBtcCodeHash: "0xbc6c568a1a0d0a09f6844dc9d74ddb4343c32143ff25f727c59edf4fb72d6936"
   rgbppBtcHashType: "type"

--- a/config.mainnet/config.yaml
+++ b/config.mainnet/config.yaml
@@ -46,7 +46,7 @@ sync:
       hashType: "data1"
       cellDep:
         outPoint:
-          txHash: "0xf6a5eef65101899db9709c8de1cc28f23c1bee90d857ebe176f6647ef109e20d"
+          txHash: "0xc07844ce21b38e4b071dd0e1ee3b0e27afd8d7532491327f39b786343f558ab7"
           index: 0
         depType: "code"
     # xUDT Compatible 1

--- a/config.mainnet/config.yaml
+++ b/config.mainnet/config.yaml
@@ -24,7 +24,7 @@ sync:
   # while clearing from db, cached txs will be removed once the `txCacheConfirmations` is set
   clearInterval: 1800000
   confirmations: 100
-  txCacheComfirmations: 100000
+  txCacheComfirmations: 1000000
 
   rgbppBtcCodeHash: "0xbc6c568a1a0d0a09f6844dc9d74ddb4343c32143ff25f727c59edf4fb72d6936"
   rgbppBtcHashType: "type"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -16,7 +16,7 @@ sync:
 
   clearInterval: 1800000
   confirmations: 100
-  txCacheComfirmations: 100000
+  txCacheComfirmations: 1000000
 
   rgbppBtcCodeHash: "0xd07598deec7ce7b5665310386b4abd06a6d48843e953c5cc2112ad0d5a220364"
   rgbppBtcHashType: "type"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -17,6 +17,7 @@ sync:
   clearInterval: 1800000
   confirmations: 100
   txCacheComfirmations: 1000000
+  txBatchMaxSize: 1048576 # 1MB
 
   rgbppBtcCodeHash: "0xd07598deec7ce7b5665310386b4abd06a6d48843e953c5cc2112ad0d5a220364"
   rgbppBtcHashType: "type"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -12,10 +12,11 @@ sync:
   threads: 8
   blockChunk: 100
   blockLimitPerInterval: 50000
-  blockSyncStart: 10228288
+  blockSyncStart: 3804
 
   clearInterval: 1800000
   confirmations: 100
+  txCacheComfirmations: 100000
 
   rgbppBtcCodeHash: "0xd07598deec7ce7b5665310386b4abd06a6d48843e953c5cc2112ad0d5a220364"
   rgbppBtcHashType: "type"

--- a/libs/asset/src/asset.controller.ts
+++ b/libs/asset/src/asset.controller.ts
@@ -356,30 +356,23 @@ export class AssetController {
         await this.service.getTransactionWithBlockByTxHash(txHash),
         RpcError.TxNotFound,
       );
-      console.time("extractInputs for txHash: " + txHash);
       const inputCells = await this.service.extractCellsFromTxInputs(
         tx,
         ccc.hexFrom(txHash),
       );
-      console.timeEnd("extractInputs for txHash: " + txHash);
-      console.time("extractOutputs for txHash: " + txHash);
       const outputCells = this.service.extractCellsFromTxOutputs(
         tx,
         ccc.hexFrom(txHash),
       );
-      console.timeEnd("extractOutputs for txHash: " + txHash);
-      console.time("extractAssetsData for txHash: " + txHash);
-      const data = await this.extractTxAssetFromTx(
-        ccc.hexFrom(txHash),
-        inputCells,
-        outputCells,
-        blockHash,
-        blockNumber,
-      );
-      console.timeEnd("extractAssetsData for txHash: " + txHash);
       return {
         code: 0,
-        data,
+        data: await this.extractTxAssetFromTx(
+          ccc.hexFrom(txHash),
+          inputCells,
+          outputCells,
+          blockHash,
+          blockNumber,
+        ),
       };
     } catch (e) {
       if (e instanceof ApiError) {

--- a/libs/asset/src/asset.controller.ts
+++ b/libs/asset/src/asset.controller.ts
@@ -357,14 +357,20 @@ export class AssetController {
         RpcError.TxNotFound,
       );
       console.time("extractInputs for txHash: " + txHash);
-      const inputCells = await this.service.extractCellsFromTxInputs(tx);
+      const inputCells = await this.service.extractCellsFromTxInputs(
+        tx,
+        ccc.hexFrom(txHash),
+      );
       console.timeEnd("extractInputs for txHash: " + txHash);
       console.time("extractOutputs for txHash: " + txHash);
-      const outputCells = this.service.extractCellsFromTxOutputs(tx);
+      const outputCells = this.service.extractCellsFromTxOutputs(
+        tx,
+        ccc.hexFrom(txHash),
+      );
       console.timeEnd("extractOutputs for txHash: " + txHash);
       console.time("extractAssetsData for txHash: " + txHash);
       const data = await this.extractTxAssetFromTx(
-        tx.hash(),
+        ccc.hexFrom(txHash),
         inputCells,
         outputCells,
         blockHash,
@@ -401,10 +407,14 @@ export class AssetController {
       );
       const txAssetCellDataList: TxAssetCellData[] = [];
       await asyncMap(block.transactions, async (tx) => {
-        const inputCells = await this.service.extractCellsFromTxInputs(tx);
-        const outputCells = this.service.extractCellsFromTxOutputs(tx);
+        const txHash = tx.hash();
+        const inputCells = await this.service.extractCellsFromTxInputs(
+          tx,
+          txHash,
+        );
+        const outputCells = this.service.extractCellsFromTxOutputs(tx, txHash);
         const txAssetCellData = await this.extractTxAssetFromTx(
-          tx.hash(),
+          txHash,
           inputCells,
           outputCells,
           block.header.hash,

--- a/libs/asset/src/asset.controller.ts
+++ b/libs/asset/src/asset.controller.ts
@@ -356,17 +356,24 @@ export class AssetController {
         await this.service.getTransactionWithBlockByTxHash(txHash),
         RpcError.TxNotFound,
       );
+      console.time("extractInputs for txHash: " + txHash);
       const inputCells = await this.service.extractCellsFromTxInputs(tx);
+      console.timeEnd("extractInputs for txHash: " + txHash);
+      console.time("extractOutputs for txHash: " + txHash);
       const outputCells = this.service.extractCellsFromTxOutputs(tx);
+      console.timeEnd("extractOutputs for txHash: " + txHash);
+      console.time("extractAssetsData for txHash: " + txHash);
+      const data = await this.extractTxAssetFromTx(
+        tx.hash(),
+        inputCells,
+        outputCells,
+        blockHash,
+        blockNumber,
+      );
+      console.timeEnd("extractAssetsData for txHash: " + txHash);
       return {
         code: 0,
-        data: await this.extractTxAssetFromTx(
-          tx.hash(),
-          inputCells,
-          outputCells,
-          blockHash,
-          blockNumber,
-        ),
+        data,
       };
     } catch (e) {
       if (e instanceof ApiError) {

--- a/libs/asset/src/asset.module.ts
+++ b/libs/asset/src/asset.module.ts
@@ -1,10 +1,16 @@
 import { Module } from "@nestjs/common";
 import { AssetController } from "./asset.controller";
 import { AssetService } from "./asset.service";
-import { ClusterRepo, SporeRepo, UdtInfoRepo } from "./repos";
+import { ClusterRepo, SporeRepo, TransactionRepo, UdtInfoRepo } from "./repos";
 
 @Module({
-  providers: [AssetService, UdtInfoRepo, SporeRepo, ClusterRepo],
+  providers: [
+    AssetService,
+    UdtInfoRepo,
+    SporeRepo,
+    ClusterRepo,
+    TransactionRepo,
+  ],
   exports: [AssetService],
   controllers: [AssetController],
 })

--- a/libs/asset/src/asset.service.ts
+++ b/libs/asset/src/asset.service.ts
@@ -246,9 +246,21 @@ export class AssetService {
       });
     const tokenAmount =
       cell.outputData.length >= 16 ? ccc.udtBalanceFrom(cell.outputData) : 0n;
+    let ownerScriptMode = lockMode;
+    if (tokenInfo.owner) {
+      if (tokenInfo.owner.startsWith("ck")) {
+        const ownerScript = await ccc.Address.fromString(
+          tokenInfo.owner,
+          this.client,
+        );
+        ownerScriptMode = await this.scriptMode(ownerScript.script);
+      } else {
+        ownerScriptMode = ScriptMode.RgbppBtc;
+      }
+    }
     return {
       tokenInfo,
-      mintable: mintableScriptMode(lockMode),
+      mintable: mintableScriptMode(ownerScriptMode),
       balance: tokenAmount,
     };
   }

--- a/libs/asset/src/asset.service.ts
+++ b/libs/asset/src/asset.service.ts
@@ -161,7 +161,10 @@ export class AssetService {
     }
   }
 
-  async extractCellsFromTxInputs(tx: ccc.Transaction): Promise<
+  async extractCellsFromTxInputs(
+    tx: ccc.Transaction,
+    txHash: ccc.Hex,
+  ): Promise<
     {
       cell: ccc.Cell;
       spender?: ccc.OutPointLike;
@@ -183,19 +186,22 @@ export class AssetService {
       }
     }
     this.logger.debug(
-      `extractCellsFromTxInputs (${tx.hash()}): ${fromDb} from db, ${fromRpc} from rpc`,
+      `extractCellsFromTxInputs (${txHash}): ${fromDb} from db, ${fromRpc} from rpc`,
     );
 
     return Array.from(outpointToCells.values()).map((cell, index) => ({
       cell: cell!,
       spender: {
-        txHash: tx.hash(),
+        txHash,
         index,
       },
     }));
   }
 
-  extractCellsFromTxOutputs(tx: ccc.Transaction): {
+  extractCellsFromTxOutputs(
+    tx: ccc.Transaction,
+    txHash: ccc.Hex,
+  ): {
     cell: ccc.Cell;
     spenderTx?: ccc.Hex;
   }[] {
@@ -204,7 +210,7 @@ export class AssetService {
       cells.push(
         ccc.Cell.from({
           outPoint: {
-            txHash: tx.hash(),
+            txHash,
             index: ccc.numFrom(index),
           },
           cellOutput: output,

--- a/libs/asset/src/asset.service.ts
+++ b/libs/asset/src/asset.service.ts
@@ -185,7 +185,7 @@ export class AssetService {
         fromDb++;
       }
     }
-    this.logger.debug(
+    console.log(
       `extractCellsFromTxInputs (${txHash}): ${fromDb} from db, ${fromRpc} from rpc`,
     );
 

--- a/libs/asset/src/repos/index.ts
+++ b/libs/asset/src/repos/index.ts
@@ -1,3 +1,4 @@
 export * from "./cluster.repo";
 export * from "./spore.repo";
+export * from "./transaction.repo";
 export * from "./udtInfo.repo";

--- a/libs/asset/src/repos/transaction.repo.ts
+++ b/libs/asset/src/repos/transaction.repo.ts
@@ -33,25 +33,32 @@ export class TransactionRepo extends Repository<Transaction> {
   async getCellsByOutpoints(
     outpoints: ccc.OutPoint[],
   ): Promise<Map<ccc.OutPoint, ccc.Cell | undefined>> {
-    const dbTxs = await this.findBy({
-      txHash: In(outpoints.map((outpoint) => outpoint.txHash)),
-    });
-    const txs = dbTxs.map((dbTx) => ccc.Transaction.fromBytes(dbTx.tx));
+    const findBatch = 500;
     const result = new Map<ccc.OutPoint, ccc.Cell | undefined>();
-    for (const outpoint of outpoints) {
-      const tx = txs.find((tx) => tx.hash() === outpoint.txHash);
-      if (!tx) {
-        result.set(outpoint, undefined);
-        continue;
+    for (let i = 0; i < outpoints.length; i += findBatch) {
+      const batch = outpoints.slice(i, i + findBatch);
+      const dbTxs = await this.findBy({
+        txHash: In(batch.map((outpoint) => outpoint.txHash)),
+      });
+      const txs = dbTxs.map((dbTx) => ({
+        txHash: dbTx.txHash,
+        payload: ccc.Transaction.fromBytes(dbTx.tx),
+      }));
+      for (const outpoint of outpoints) {
+        const tx = txs.find((tx) => tx.txHash === outpoint.txHash);
+        if (!tx) {
+          result.set(outpoint, undefined);
+          continue;
+        }
+        result.set(
+          outpoint,
+          ccc.Cell.from({
+            outPoint: outpoint,
+            cellOutput: tx.payload.outputs[Number(outpoint.index)],
+            outputData: tx.payload.outputsData[Number(outpoint.index)],
+          }),
+        );
       }
-      result.set(
-        outpoint,
-        ccc.Cell.from({
-          outPoint: outpoint,
-          cellOutput: tx.outputs[Number(outpoint.index)],
-          outputData: tx.outputsData[Number(outpoint.index)],
-        }),
-      );
     }
     return result;
   }

--- a/libs/asset/src/repos/transaction.repo.ts
+++ b/libs/asset/src/repos/transaction.repo.ts
@@ -1,0 +1,58 @@
+import { Transaction } from "@app/schemas";
+import { ccc } from "@ckb-ccc/shell";
+import { Injectable } from "@nestjs/common";
+import { EntityManager, In, Repository } from "typeorm";
+
+@Injectable()
+export class TransactionRepo extends Repository<Transaction> {
+  constructor(manager: EntityManager) {
+    super(Transaction, manager);
+  }
+
+  async getTransactionByTxHash(
+    txHash: ccc.Hex,
+  ): Promise<Transaction | undefined> {
+    return (await this.findOneBy({ txHash })) ?? undefined;
+  }
+
+  async getCellByOutpoint(
+    outpoint: ccc.OutPoint,
+  ): Promise<ccc.Cell | undefined> {
+    const dbTx = await this.findOneBy({ txHash: outpoint.txHash });
+    if (!dbTx) {
+      return undefined;
+    }
+    const tx = ccc.Transaction.fromBytes(dbTx.tx);
+    return ccc.Cell.from({
+      outPoint: outpoint,
+      cellOutput: tx.outputs[Number(outpoint.index)],
+      outputData: tx.outputsData[Number(outpoint.index)],
+    });
+  }
+
+  async getCellsByOutpoints(
+    outpoints: ccc.OutPoint[],
+  ): Promise<Map<ccc.OutPoint, ccc.Cell | undefined>> {
+    const dbTxs = await this.findBy({
+      txHash: In(outpoints.map((outpoint) => outpoint.txHash)),
+    });
+    const txs = dbTxs.map((dbTx) => ccc.Transaction.fromBytes(dbTx.tx));
+    const result = new Map<ccc.OutPoint, ccc.Cell | undefined>();
+    for (const outpoint of outpoints) {
+      const tx = txs.find((tx) => tx.hash() === outpoint.txHash);
+      if (!tx) {
+        result.set(outpoint, undefined);
+        continue;
+      }
+      result.set(
+        outpoint,
+        ccc.Cell.from({
+          outPoint: outpoint,
+          cellOutput: tx.outputs[Number(outpoint.index)],
+          outputData: tx.outputsData[Number(outpoint.index)],
+        }),
+      );
+    }
+    return result;
+  }
+}

--- a/libs/cell/src/cell.module.ts
+++ b/libs/cell/src/cell.module.ts
@@ -1,10 +1,10 @@
 import { Module } from "@nestjs/common";
 import { CellController } from "./cell.controller";
 import { CellService } from "./cell.service";
-import { UdtBalanceRepo, UdtInfoRepo } from "./repos";
+import { TransactionRepo, UdtBalanceRepo, UdtInfoRepo } from "./repos";
 
 @Module({
-  providers: [CellService, UdtInfoRepo, UdtBalanceRepo],
+  providers: [CellService, UdtInfoRepo, UdtBalanceRepo, TransactionRepo],
   exports: [CellService],
   controllers: [CellController],
 })

--- a/libs/cell/src/repos/index.ts
+++ b/libs/cell/src/repos/index.ts
@@ -1,2 +1,3 @@
+export * from "./transaction.repo";
 export * from "./udtBalance.repo";
 export * from "./udtInfo.repo";

--- a/libs/cell/src/repos/transaction.repo.ts
+++ b/libs/cell/src/repos/transaction.repo.ts
@@ -33,25 +33,32 @@ export class TransactionRepo extends Repository<Transaction> {
   async getCellsByOutpoints(
     outpoints: ccc.OutPoint[],
   ): Promise<Map<ccc.OutPoint, ccc.Cell | undefined>> {
-    const dbTxs = await this.findBy({
-      txHash: In(outpoints.map((outpoint) => outpoint.txHash)),
-    });
-    const txs = dbTxs.map((dbTx) => ccc.Transaction.fromBytes(dbTx.tx));
+    const findBatch = 500;
     const result = new Map<ccc.OutPoint, ccc.Cell | undefined>();
-    for (const outpoint of outpoints) {
-      const tx = txs.find((tx) => tx.hash() === outpoint.txHash);
-      if (!tx) {
-        result.set(outpoint, undefined);
-        continue;
+    for (let i = 0; i < outpoints.length; i += findBatch) {
+      const batch = outpoints.slice(i, i + findBatch);
+      const dbTxs = await this.findBy({
+        txHash: In(batch.map((outpoint) => outpoint.txHash)),
+      });
+      const txs = dbTxs.map((dbTx) => ({
+        txHash: dbTx.txHash,
+        payload: ccc.Transaction.fromBytes(dbTx.tx),
+      }));
+      for (const outpoint of outpoints) {
+        const tx = txs.find((tx) => tx.txHash === outpoint.txHash);
+        if (!tx) {
+          result.set(outpoint, undefined);
+          continue;
+        }
+        result.set(
+          outpoint,
+          ccc.Cell.from({
+            outPoint: outpoint,
+            cellOutput: tx.payload.outputs[Number(outpoint.index)],
+            outputData: tx.payload.outputsData[Number(outpoint.index)],
+          }),
+        );
       }
-      result.set(
-        outpoint,
-        ccc.Cell.from({
-          outPoint: outpoint,
-          cellOutput: tx.outputs[Number(outpoint.index)],
-          outputData: tx.outputsData[Number(outpoint.index)],
-        }),
-      );
     }
     return result;
   }

--- a/libs/cell/src/repos/transaction.repo.ts
+++ b/libs/cell/src/repos/transaction.repo.ts
@@ -1,0 +1,58 @@
+import { Transaction } from "@app/schemas";
+import { ccc } from "@ckb-ccc/shell";
+import { Injectable } from "@nestjs/common";
+import { EntityManager, In, Repository } from "typeorm";
+
+@Injectable()
+export class TransactionRepo extends Repository<Transaction> {
+  constructor(manager: EntityManager) {
+    super(Transaction, manager);
+  }
+
+  async getTransactionByTxHash(
+    txHash: ccc.Hex,
+  ): Promise<Transaction | undefined> {
+    return (await this.findOneBy({ txHash })) ?? undefined;
+  }
+
+  async getCellByOutpoint(
+    outpoint: ccc.OutPoint,
+  ): Promise<ccc.Cell | undefined> {
+    const dbTx = await this.findOneBy({ txHash: outpoint.txHash });
+    if (!dbTx) {
+      return undefined;
+    }
+    const tx = ccc.Transaction.fromBytes(dbTx.tx);
+    return ccc.Cell.from({
+      outPoint: outpoint,
+      cellOutput: tx.outputs[Number(outpoint.index)],
+      outputData: tx.outputsData[Number(outpoint.index)],
+    });
+  }
+
+  async getCellsByOutpoints(
+    outpoints: ccc.OutPoint[],
+  ): Promise<Map<ccc.OutPoint, ccc.Cell | undefined>> {
+    const dbTxs = await this.findBy({
+      txHash: In(outpoints.map((outpoint) => outpoint.txHash)),
+    });
+    const txs = dbTxs.map((dbTx) => ccc.Transaction.fromBytes(dbTx.tx));
+    const result = new Map<ccc.OutPoint, ccc.Cell | undefined>();
+    for (const outpoint of outpoints) {
+      const tx = txs.find((tx) => tx.hash() === outpoint.txHash);
+      if (!tx) {
+        result.set(outpoint, undefined);
+        continue;
+      }
+      result.set(
+        outpoint,
+        ccc.Cell.from({
+          outPoint: outpoint,
+          cellOutput: tx.outputs[Number(outpoint.index)],
+          outputData: tx.outputsData[Number(outpoint.index)],
+        }),
+      );
+    }
+    return result;
+  }
+}

--- a/libs/commons/src/utils/index.ts
+++ b/libs/commons/src/utils/index.ts
@@ -132,6 +132,7 @@ export const RgbppLockArgs = ccc.mol.struct({
 export const ScriptVecOpt = ccc.mol.option(ccc.mol.vector(ccc.Script));
 export const ScriptOpt = ccc.mol.option(ccc.Script);
 
+// Refer to https://github.com/nervosnetwork/ckb-production-scripts/blob/master/c/xudt_rce.mol#L6
 export const XudtWitness = ccc.mol.table({
   owner_script: ScriptOpt,
   owner_signature: ccc.mol.BytesOpt,

--- a/libs/commons/src/utils/index.ts
+++ b/libs/commons/src/utils/index.ts
@@ -380,22 +380,24 @@ export function findOwnerScriptFromIssuanceTx(
 
   // Otherwise falling back to tx.Witnesses (xUDT specific)
   for (const witness of tx.witnesses) {
-    const witnessArgs = ccc.WitnessArgs.fromBytes(witness);
-    if (witnessArgs.inputType) {
-      try {
-        const xudtWitness = XudtWitness.decode(witnessArgs.inputType);
-        if (xudtWitness.owner_script?.hash() === ownerScriptHash) {
-          return xudtWitness.owner_script;
-        }
-      } catch (_) {}
-    }
-    if (witnessArgs.outputType) {
-      try {
-        const xudtWitness = XudtWitness.decode(witnessArgs.outputType);
-        if (xudtWitness.owner_script?.hash() === ownerScriptHash) {
-          return xudtWitness.owner_script;
-        }
-      } catch (_) {}
-    }
+    try {
+      const witnessArgs = ccc.WitnessArgs.fromBytes(witness);
+      if (witnessArgs.inputType) {
+        try {
+          const xudtWitness = XudtWitness.decode(witnessArgs.inputType);
+          if (xudtWitness.owner_script?.hash() === ownerScriptHash) {
+            return xudtWitness.owner_script;
+          }
+        } catch (_) {}
+      }
+      if (witnessArgs.outputType) {
+        try {
+          const xudtWitness = XudtWitness.decode(witnessArgs.outputType);
+          if (xudtWitness.owner_script?.hash() === ownerScriptHash) {
+            return xudtWitness.owner_script;
+          }
+        } catch (_) {}
+      }
+    } catch (_) {}
   }
 }

--- a/libs/commons/src/utils/index.ts
+++ b/libs/commons/src/utils/index.ts
@@ -129,6 +129,16 @@ export const RgbppLockArgs = ccc.mol.struct({
   }),
 });
 
+export const ScriptVecOpt = ccc.mol.option(ccc.mol.vector(ccc.Script));
+export const ScriptOpt = ccc.mol.option(ccc.Script);
+
+export const XudtWitness = ccc.mol.table({
+  owner_script: ScriptOpt,
+  owner_signature: ccc.mol.BytesOpt,
+  extension_scripts: ScriptVecOpt,
+  extension_data: ccc.mol.BytesVec,
+});
+
 export function headerToRepoBlock(
   header: ccc.ClientBlockHeader | undefined,
 ): Block | undefined {

--- a/libs/schemas/src/schemas.module.ts
+++ b/libs/schemas/src/schemas.module.ts
@@ -7,6 +7,7 @@ import {
   ScriptCode,
   Spore,
   SyncStatus,
+  Transaction,
   UdtBalance,
   UdtInfo,
 } from "./schemas";
@@ -31,6 +32,7 @@ import {
           UdtBalance,
           Spore,
           Cluster,
+          Transaction,
         ],
       }),
     }),

--- a/libs/schemas/src/schemas/index.ts
+++ b/libs/schemas/src/schemas/index.ts
@@ -3,5 +3,6 @@ export * from "./cluster";
 export * from "./scriptCode";
 export * from "./spore";
 export * from "./syncStatus";
+export * from "./transaction";
 export * from "./udtBalance";
 export * from "./udtInfo";

--- a/libs/schemas/src/schemas/transaction.ts
+++ b/libs/schemas/src/schemas/transaction.ts
@@ -1,0 +1,39 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from "typeorm";
+
+@Entity()
+@Index(["txHash", "updatedAtHeight", "blockHash"], { unique: true })
+export class Transaction {
+  @PrimaryGeneratedColumn("increment")
+  id: number;
+
+  @Column({ type: "varchar" })
+  @Index({ unique: true })
+  txHash: string;
+
+  @Column({ type: "varchar" })
+  blockHash: string;
+
+  @Column({ type: "int" })
+  txIndex: number;
+
+  @Column({ type: "mediumtext" })
+  tx: string;
+
+  // To roll back on re-org
+  @Column({ type: "varchar" })
+  @Index()
+  updatedAtHeight: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/libs/schemas/src/schemas/transaction.ts
+++ b/libs/schemas/src/schemas/transaction.ts
@@ -8,26 +8,19 @@ import {
 } from "typeorm";
 
 @Entity()
-@Index(["txHash", "updatedAtHeight", "blockHash"], { unique: true })
 export class Transaction {
   @PrimaryGeneratedColumn("increment")
   id: number;
 
   @Column({ type: "varchar" })
+  @Index({ unique: true })
   txHash: string;
-
-  @Column({ type: "varchar" })
-  blockHash: string;
-
-  @Column({ type: "int" })
-  txIndex: number;
 
   @Column({ type: "mediumtext" })
   tx: string;
 
-  // To roll back on re-org
+  // To provide evidence for data cleanup, this table won't be rolled back on re-org
   @Column({ type: "varchar" })
-  @Index()
   updatedAtHeight: string;
 
   @CreateDateColumn()

--- a/libs/schemas/src/schemas/transaction.ts
+++ b/libs/schemas/src/schemas/transaction.ts
@@ -14,7 +14,6 @@ export class Transaction {
   id: number;
 
   @Column({ type: "varchar" })
-  @Index({ unique: true })
   txHash: string;
 
   @Column({ type: "varchar" })

--- a/libs/schemas/src/schemas/transaction.ts
+++ b/libs/schemas/src/schemas/transaction.ts
@@ -16,8 +16,8 @@ export class Transaction {
   @Index({ unique: true })
   txHash: string;
 
-  @Column({ type: "mediumtext" })
-  tx: string;
+  @Column({ type: "mediumblob" })
+  tx: Buffer;
 
   // To provide evidence for data cleanup, this table won't be rolled back on re-org
   @Column({ type: "varchar" })

--- a/libs/sync/src/repos/index.ts
+++ b/libs/sync/src/repos/index.ts
@@ -3,5 +3,6 @@ export * from "./cluster.repo";
 export * from "./scriptCode.repo";
 export * from "./spore.repo";
 export * from "./syncStatus.repo";
+export * from "./transaction.repo";
 export * from "./udtBalance.repo";
 export * from "./udtInfo.repo";

--- a/libs/sync/src/repos/transaction.repo.ts
+++ b/libs/sync/src/repos/transaction.repo.ts
@@ -1,0 +1,17 @@
+import { Transaction } from "@app/schemas";
+import { ccc } from "@ckb-ccc/shell";
+import { Injectable } from "@nestjs/common";
+import { EntityManager, Repository } from "typeorm";
+
+@Injectable()
+export class TransactionRepo extends Repository<Transaction> {
+  constructor(manager: EntityManager) {
+    super(Transaction, manager);
+  }
+
+  async getTransactionByTxHash(
+    txHash: ccc.Hex,
+  ): Promise<Transaction | undefined> {
+    return (await this.findOneBy({ txHash })) ?? undefined;
+  }
+}

--- a/libs/sync/src/sporeParser.ts
+++ b/libs/sync/src/sporeParser.ts
@@ -441,10 +441,11 @@ class SporeParser {
       async (entityManager) => {
         const sporeRepo = new SporeRepo(entityManager);
         const clusterRepo = new ClusterRepo(entityManager);
+        const txHash = tx.hash();
 
         for (const [sporeId, flow] of Object.entries(flows.sporeFlows)) {
           await this.handleSporeFlow(
-            tx.hash(),
+            txHash,
             ccc.hexFrom(sporeId),
             flow,
             sporeRepo,
@@ -454,7 +455,7 @@ class SporeParser {
 
         for (const [clusterId, flow] of Object.entries(flows.clusterFlows)) {
           await this.handleClusterFlow(
-            tx.hash(),
+            txHash,
             ccc.hexFrom(clusterId),
             flow,
             clusterRepo,

--- a/libs/sync/src/sync.module.ts
+++ b/libs/sync/src/sync.module.ts
@@ -2,6 +2,7 @@ import { Module } from "@nestjs/common";
 import {
   ScriptCodeRepo,
   SyncStatusRepo,
+  TransactionRepo,
   UdtBalanceRepo,
   UdtInfoRepo,
 } from "./repos";
@@ -25,6 +26,7 @@ import { UdtParser } from "./udtParser";
     UdtInfoRepo,
     SporeRepo,
     ClusterRepo,
+    TransactionRepo,
   ],
   exports: [SyncService, UdtParser, SporeParserBuilder],
   controllers: [SyncController],

--- a/libs/sync/src/sync.service.ts
+++ b/libs/sync/src/sync.service.ts
@@ -394,6 +394,10 @@ export class SyncService {
               // If it's the last transaction, commit the transaction and break
               if (j === block.transactions.length - 1) {
                 break;
+              } else if (totalTxSize >= MAX_TX_SIZE) {
+                this.logger.debug(
+                  `Total tx size: ${totalTxSize}, ${j} transactions processed`,
+                );
               }
 
               // Commit the transaction and start a new one

--- a/libs/sync/src/sync.service.ts
+++ b/libs/sync/src/sync.service.ts
@@ -361,10 +361,6 @@ export class SyncService {
                 tx: molTx,
                 updatedAtHeight: formatSortableInt(height),
               });
-              // For JavaScript GC
-              cccTx.inputs = [];
-              cccTx.outputs = [];
-              cccTx.outputsData = [];
 
               totalTxSize += molTx.length;
               if (
@@ -406,12 +402,6 @@ export class SyncService {
               totalTxSize = 0;
               i = j;
               objects.length = 0;
-
-              if (global.gc) {
-                global.gc();
-              } else {
-                await new Promise((resolve) => setTimeout(resolve, 100));
-              }
             }
           },
         );

--- a/libs/sync/src/sync.service.ts
+++ b/libs/sync/src/sync.service.ts
@@ -337,13 +337,18 @@ export class SyncService {
         await Promise.all(
           block.transactions.map((tx, index) => {
             const cccTx = ccc.Transaction.from(tx);
-            return this.transactionRepo.create({
-              txHash: ccc.hexFrom(cccTx.hash()),
-              blockHash: block.header.hash,
-              txIndex: index,
-              tx: ccc.hexFrom(cccTx.toBytes()),
-              updatedAtHeight: formatSortableInt(height),
-            });
+            return this.transactionRepo
+              .createQueryBuilder()
+              .insert()
+              .values({
+                txHash: ccc.hexFrom(cccTx.hash()),
+                blockHash: block.header.hash,
+                txIndex: index,
+                tx: ccc.hexFrom(cccTx.toBytes()),
+                updatedAtHeight: formatSortableInt(height),
+              })
+              .orIgnore()
+              .execute();
           }),
         );
         /* === Save block transactions === */

--- a/libs/sync/src/sync.service.ts
+++ b/libs/sync/src/sync.service.ts
@@ -334,7 +334,7 @@ export class SyncService {
         }
 
         /* === Save block transactions === */
-        await Promise.all(
+        await Promise.allSettled(
           block.transactions.map(async (tx, index) => {
             const cccTx = ccc.Transaction.from(tx);
             try {
@@ -350,7 +350,6 @@ export class SyncService {
                 `Failed to save transaction ${ccc.hexFrom(cccTx.hash())}`,
                 error,
               );
-              return null;
             }
           }),
         );

--- a/libs/sync/src/sync.service.ts
+++ b/libs/sync/src/sync.service.ts
@@ -372,7 +372,7 @@ export class SyncService {
             const tx = ccc.Transaction.from(txLike);
 
             // Complete extra infos for inputs, read from db at first, otherwise fetch from rpc
-            for (const input of tx.inputs) {
+            for (const [i, input] of tx.inputs.entries()) {
               const txHash = ccc.hexFrom(input.previousOutput.txHash);
               const index = Number(input.previousOutput.index);
               const prevTx = await this.transactionRepo.findOne({
@@ -385,6 +385,7 @@ export class SyncService {
               } else {
                 await input.completeExtraInfos(this.client);
               }
+              tx.inputs[i] = input;
             }
 
             const diffs = await this.udtParser.udtInfoHandleTx(tx);

--- a/libs/sync/src/sync.service.ts
+++ b/libs/sync/src/sync.service.ts
@@ -350,6 +350,7 @@ export class SyncService {
                 `Failed to save transaction ${ccc.hexFrom(cccTx.hash())}`,
                 error,
               );
+              return null;
             }
           }),
         );

--- a/libs/sync/src/sync.service.ts
+++ b/libs/sync/src/sync.service.ts
@@ -337,19 +337,20 @@ export class SyncService {
         await Promise.all(
           block.transactions.map(async (tx, index) => {
             const cccTx = ccc.Transaction.from(tx);
-            const existed = await this.transactionRepo.findOneBy({
-              txHash: ccc.hexFrom(cccTx.hash()),
-            });
-            if (existed) {
-              return;
+            try {
+              return this.transactionRepo.save({
+                txHash: ccc.hexFrom(cccTx.hash()),
+                blockHash: block.header.hash,
+                txIndex: index,
+                tx: ccc.hexFrom(cccTx.toBytes()),
+                updatedAtHeight: formatSortableInt(height),
+              });
+            } catch (error) {
+              this.logger.error(
+                `Failed to save transaction ${ccc.hexFrom(cccTx.hash())}`,
+                error,
+              );
             }
-            return this.transactionRepo.insert({
-              txHash: ccc.hexFrom(cccTx.hash()),
-              blockHash: block.header.hash,
-              txIndex: index,
-              tx: ccc.hexFrom(cccTx.toBytes()),
-              updatedAtHeight: formatSortableInt(height),
-            });
           }),
         );
         /* === Save block transactions === */

--- a/libs/sync/src/udtParser.ts
+++ b/libs/sync/src/udtParser.ts
@@ -207,7 +207,7 @@ export class UdtParser {
             }
 
             if (!udtOwner) {
-              this.logger.error(
+              throw new Error(
                 `No owner found for token ${tokenHash} at tx ${txHash}`,
               );
             }

--- a/libs/sync/src/udtParser.ts
+++ b/libs/sync/src/udtParser.ts
@@ -201,7 +201,12 @@ export class UdtParser {
 
             if (!udtOwner) {
               // Uncompatible xUDT specification
-              this.logger.error(
+              // this.logger.error(
+              //   `Uncompatible xUDT specification for token ${tokenHash}`,
+              // );
+
+              // Currently, throw error to stop the sync process for debugging
+              throw new Error(
                 `Uncompatible xUDT specification for token ${tokenHash}`,
               );
             }

--- a/libs/sync/src/udtParser.ts
+++ b/libs/sync/src/udtParser.ts
@@ -207,7 +207,7 @@ export class UdtParser {
 
               // Currently, throw error to stop the sync process for debugging
               throw new Error(
-                `Uncompatible xUDT specification for token ${tokenHash}`,
+                `Uncompatible xUDT specification for token ${tokenHash} at tx ${txHash}`,
               );
             }
           }

--- a/libs/sync/src/udtParser.ts
+++ b/libs/sync/src/udtParser.ts
@@ -162,11 +162,12 @@ export class UdtParser {
               udtType.script.args,
             );
             if (!ownerScript) {
-              throw new Error(
+              this.logger.error(
                 `No owner found for token ${tokenHash} at tx ${txHash}`,
               );
+            } else {
+              udtOwner = await this.scriptToAddress(ownerScript);
             }
-            udtOwner = await this.scriptToAddress(ownerScript);
           }
 
           const udtInfo = udtInfoRepo.create({

--- a/libs/sync/src/udtParser.ts
+++ b/libs/sync/src/udtParser.ts
@@ -199,13 +199,7 @@ export class UdtParser {
               }
             }
 
-            if (!udtOwner) {
-              // Uncompatible xUDT specification
-              // this.logger.error(
-              //   `Uncompatible xUDT specification for token ${tokenHash}`,
-              // );
-
-              // Currently, throw error to stop the sync process for debugging
+            if (!udtOwner && diffs.some((d) => d.balance > ccc.Zero)) {
               throw new Error(
                 `Uncompatible xUDT specification for token ${tokenHash} at tx ${txHash}`,
               );

--- a/libs/sync/src/udtParser.ts
+++ b/libs/sync/src/udtParser.ts
@@ -169,9 +169,9 @@ export class UdtParser {
             // Otherwise falling back to tx.Witnesses (xUDT specific)
             if (!udtOwner) {
               for (const witness of tx.witnesses) {
-                try {
-                  const witnessArgs = ccc.WitnessArgs.fromBytes(witness);
-                  if (witnessArgs.inputType) {
+                const witnessArgs = ccc.WitnessArgs.fromBytes(witness);
+                if (witnessArgs.inputType) {
+                  try {
                     const xudtWitness = XudtWitness.decode(
                       witnessArgs.inputType,
                     );
@@ -181,8 +181,10 @@ export class UdtParser {
                       );
                       break;
                     }
-                  }
-                  if (witnessArgs.outputType) {
+                  } catch (_) {}
+                }
+                if (witnessArgs.outputType) {
+                  try {
                     const xudtWitness = XudtWitness.decode(
                       witnessArgs.outputType,
                     );
@@ -192,15 +194,17 @@ export class UdtParser {
                       );
                       break;
                     }
-                  }
-                } catch (_) {}
+                  } catch (_) {}
+                }
               }
             }
 
-            // Uncompatible xUDT specification
-            this.logger.error(
-              `Uncompatible xUDT specification for token ${tokenHash}`,
-            );
+            if (!udtOwner) {
+              // Uncompatible xUDT specification
+              this.logger.error(
+                `Uncompatible xUDT specification for token ${tokenHash}`,
+              );
+            }
           }
 
           const udtInfo = udtInfoRepo.create({

--- a/libs/sync/src/udtParser.ts
+++ b/libs/sync/src/udtParser.ts
@@ -168,7 +168,7 @@ export class UdtParser {
 
             // Otherwise falling back to tx.Witnesses (xUDT specific)
             if (!udtOwner) {
-              for (const witness of tx.witnesses) {
+              for (const [i, witness] of tx.witnesses.entries()) {
                 const witnessArgs = ccc.WitnessArgs.fromBytes(witness);
                 if (witnessArgs.inputType) {
                   try {
@@ -181,7 +181,12 @@ export class UdtParser {
                       );
                       break;
                     }
-                  } catch (_) {}
+                  } catch (error) {
+                    this.logger.warn(
+                      `Failed to decode xUDT witness for token ${tokenHash} at tx ${txHash} (witness/inputType ${i})`,
+                      error,
+                    );
+                  }
                 }
                 if (witnessArgs.outputType) {
                   try {
@@ -194,7 +199,12 @@ export class UdtParser {
                       );
                       break;
                     }
-                  } catch (_) {}
+                  } catch (error) {
+                    this.logger.warn(
+                      `Failed to decode xUDT witness for token ${tokenHash} at tx ${txHash} (witness/outputType ${i})`,
+                      error,
+                    );
+                  }
                 }
               }
             }

--- a/libs/udt/src/udt.controller.ts
+++ b/libs/udt/src/udt.controller.ts
@@ -113,10 +113,24 @@ export class UdtController {
           break;
         }
       }
-      const ownerScript = findOwnerScriptFromIssuanceTx(
-        issueTx,
-        ccc.hexFrom(udtInfo.typeArgs),
-      );
+      let ownerScript: ccc.Script | undefined;
+      if (udtInfo.owner) {
+        const ownerAddress = await ccc.Address.fromString(
+          udtInfo.owner,
+          this.service.client,
+        );
+        ownerScript = ownerAddress.script;
+      } else {
+        await Promise.all(
+          issueTx.inputs.map(async (input) => {
+            await input.completeExtraInfos(this.service.client);
+          }),
+        );
+        ownerScript = findOwnerScriptFromIssuanceTx(
+          issueTx,
+          ccc.hexFrom(udtInfo.typeArgs),
+        );
+      }
       const mintable = ownerScript
         ? mintableScriptMode(await this.service.scriptMode(ownerScript))
         : false;

--- a/libs/udt/src/udt.service.ts
+++ b/libs/udt/src/udt.service.ts
@@ -17,7 +17,7 @@ import { ScriptCodeRepo } from "./repos/scriptCode.repo";
 
 @Injectable()
 export class UdtService {
-  private readonly client: ccc.Client;
+  public readonly client: ccc.Client;
   private readonly rgbppBtcCodeHash: ccc.Hex;
   private readonly rgbppBtcHashType: ccc.HashType;
   private readonly udtTypes: Record<ccc.Hex, ccc.CellDepLike>;

--- a/workers/getBlock.ts
+++ b/workers/getBlock.ts
@@ -38,7 +38,7 @@ export async function* getBlocks(
                   ) {
                     return;
                   }
-                  // await i.completeExtraInfos(client);
+                  await i.completeExtraInfos(client);
                 });
               })
               .flat(),

--- a/workers/getBlock.ts
+++ b/workers/getBlock.ts
@@ -30,7 +30,7 @@ export async function* getBlocks(
           parsing: Promise.all(
             (block?.transactions ?? [])
               .map((tx) => {
-                tx.witnesses = [];
+                // tx.witnesses = [];
                 return tx.inputs.map(async (i) => {
                   if (
                     i.previousOutput.txHash ===

--- a/workers/getBlock.ts
+++ b/workers/getBlock.ts
@@ -38,7 +38,7 @@ export async function* getBlocks(
                   ) {
                     return;
                   }
-                  await i.completeExtraInfos(client);
+                  // await i.completeExtraInfos(client);
                 });
               })
               .flat(),

--- a/workers/getBlock.ts
+++ b/workers/getBlock.ts
@@ -94,6 +94,7 @@ parentPort?.addListener("message", ({ start, end }) =>
         isSsriUdt: boolean;
       }[] = [];
       for (const tx of block.block?.transactions ?? []) {
+        const txHash = tx.hash();
         await Promise.all(
           tx.outputs.map(async (output, i) => {
             const data = tx.outputsData[i];
@@ -104,7 +105,7 @@ parentPort?.addListener("message", ({ start, end }) =>
             }
 
             const outPoint = {
-              txHash: tx.hash(),
+              txHash,
               index: i,
             };
 
@@ -131,7 +132,7 @@ parentPort?.addListener("message", ({ start, end }) =>
 
             scriptCodes.push({
               outPoint: {
-                txHash: tx.hash(),
+                txHash,
                 index: i,
               },
               size: data.length / 2 - 1,


### PR DESCRIPTION
# Description

1. save every transactions from syncing point into db
2. read tx from db in every transaction fetching request, otherwise, read from rpc instead
3. parse udt owner from the issuance transaction, then record into db

notice: assets APIs have significantly speed up