### PR TITLE
bug: fallback to ckb address if btcTxId is invalid

### DIFF
--- a/libs/commons/src/utils/index.ts
+++ b/libs/commons/src/utils/index.ts
@@ -250,6 +250,13 @@ export async function parseBtcAddress(params: {
     return ckbAddress;
   }
   const { outIndex, txId } = decoded;
+  // Check if txId is a standard 32-byte hex string (with 0x prefix)
+  if (txId.length !== 66) {
+    logger?.warn(
+      `Invalid BTC txId format: ${txId}. Expected 0x-prefixed 32-byte hex string.`,
+    );
+    return ckbAddress;
+  }
 
   let fallbackToCkb = false;
   for (const requester of requesters) {


### PR DESCRIPTION
# Description

while syncing on mainnet, there's an empty btc txId in the first output of tx: https://explorer.nervos.org/transaction/0x3bfbb2d649032cace15439667f546a3b13c8bf27b1e76979e7014ef4465f4652

which leads to the errors below:

<img width="1365" alt="image" src="https://github.com/user-attachments/assets/bfaadd0d-5b02-40d3-9806-a9c3175acdc0" />


note: the weird thing is I don't know why our mainnet ckb-indexer in the test server works fine